### PR TITLE
Exclude tail-end spikes and fix cluster-specific function

### DIFF
--- a/dlab/kilo.py
+++ b/dlab/kilo.py
@@ -624,9 +624,7 @@ def group_spikes_script(argv=None):
         spikes = cluster[
             (cluster.time > n_before) & (cluster.time < (nsamples - n_after))
         ]
-        if len(spikes) < len(cluster):
-            log.info("    - %d spike(s) with insufficient samples excluded", len(cluster) - len(spikes))
-            n_spikes = len(spikes)
+        n_clean = len(spikes)
         waveforms = qs.peaks(
             recording[:, clust_info["ch"]],
             spikes.time,
@@ -638,15 +636,21 @@ def group_spikes_script(argv=None):
             np.abs(mean_spike).max(-1) * args.artifact_reject_thresh
         )
         n_included = included.sum()
-        if n_included == 0:
-            log.warning("   - all spikes marked as artifacts (sorting error?)")
-            continue
-        elif n_included < n_spikes:
+
+        if (n_clean < n_spikes) & (n_clean > n_spikes-2) :
+            log.info("    - %d spike(s) with insufficient samples excluded.", n_spikes - n_clean)
+        if (n_included < n_clean) & (n_included > n_clean/2):
             spikes = spikes[included]
             waveforms = waveforms[included]
             log.info("    - %d artifact spike(s) excluded", n_spikes - n_included)
-            # aggregate spikes by trial and left join to trial information table
-            # - empty trials will be nan
+
+        if (n_included < n_clean/2) | (n_clean < n_spikes-2):
+            log.warning("    - too many spikes in cluster %d excluded as artifact or tail spikes. Recheck sorting data.", clust_id)
+            input("group-kilo-spikes will skip this unit. Press any key to continue.")
+            continue
+
+        # aggregate spikes by trial and left join to trial information table
+        # - empty trials will be nan
         clust_trials = trials.join(
             spikes.groupby("trial")
             .apply(lambda x: x.time.to_numpy(), include_groups=False)

--- a/dlab/kilo.py
+++ b/dlab/kilo.py
@@ -624,6 +624,9 @@ def group_spikes_script(argv=None):
         spikes = cluster[
             (cluster.time > n_before) & (cluster.time < (nsamples - n_after))
         ]
+        if len(spikes) < len(cluster):
+            log.info("    - %d spike(s) with insufficient samples excluded", len(cluster) - len(spikes))
+            n_spikes = len(spikes)
         waveforms = qs.peaks(
             recording[:, clust_info["ch"]],
             spikes.time,
@@ -639,13 +642,13 @@ def group_spikes_script(argv=None):
             log.warning("   - all spikes marked as artifacts (sorting error?)")
             continue
         elif n_included < n_spikes:
-            cluster = cluster[included]
+            spikes = spikes[included]
             waveforms = waveforms[included]
             log.info("    - %d artifact spike(s) excluded", n_spikes - n_included)
             # aggregate spikes by trial and left join to trial information table
             # - empty trials will be nan
         clust_trials = trials.join(
-            cluster.groupby("trial")
+            spikes.groupby("trial")
             .apply(lambda x: x.time.to_numpy(), include_groups=False)
             .rename("events")
         )
@@ -684,7 +687,7 @@ def group_spikes_script(argv=None):
                     outfile,
                     SpikeWaveforms(
                         waveforms,
-                        cluster.time.to_numpy(),
+                        spikes.time.to_numpy(),
                         params["sampling_rate"],
                         n_before,
                     ),

--- a/dlab/kilo.py
+++ b/dlab/kilo.py
@@ -548,7 +548,7 @@ def group_spikes_script(argv=None):
     log.info("    - %d samples, %d channels", nsamples, nchannels)
     if args.cluster is not None:
         log.info("- only analyzing clusters: %s", args.cluster)
-        events = events[events.clust == args.cluster]
+        events = events[events.clust.isin(args.cluster)]
 
     # find duplicates - this is rare but needs to be caught
     duplicates = events.duplicated()

--- a/dlab/kilo.py
+++ b/dlab/kilo.py
@@ -548,7 +548,7 @@ def group_spikes_script(argv=None):
     log.info("    - %d samples, %d channels", nsamples, nchannels)
     if args.cluster is not None:
         log.info("- only analyzing clusters: %s", args.cluster)
-        events = events[events.cluster == args.cluster]
+        events = events[events.clust == args.cluster]
 
     # find duplicates - this is rare but needs to be caught
     duplicates = events.duplicated()


### PR DESCRIPTION
Instead of using `cluster` for spike times, the `spikes` variable in place already excludes starting and ending spikes without enough samples to be saved. `spikes` and `waveforms` will match the number of spikes. Added logging info for # of spikes dropped. Fixes #43 
Also, added a small change to get the `cluster` arg working.